### PR TITLE
fix: upgrade alpine version

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,8 @@
-FROM alpine:3.18
+FROM alpine:3.18.0
 
 RUN apk add --no-cache ca-certificates \
+    # upgrade openssl package to fix vulnerabilities
+    && apk add openssl \
     && rm -rf /var/cache/apk/*
 
 ADD build/xelon-cloud-controller-manager /bin/

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.18
 
 RUN apk add --no-cache ca-certificates \
     && rm -rf /var/cache/apk/*

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.18
 
 RUN apk add --no-cache ca-certificates \
     && rm -rf /var/cache/apk/*

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,6 +1,8 @@
-FROM alpine:3.18
+FROM alpine:3.18.0
 
 RUN apk add --no-cache ca-certificates \
+    # upgrade openssl package to fix vulnerabilities
+    && apk add openssl \
     && rm -rf /var/cache/apk/*
 
 ADD xelon-cloud-controller-manager /bin/


### PR DESCRIPTION
This PR upgrades alpine image to 3.18.0.

`openssl` package is updated to fix https://dso.docker.com/cve/CVE-2023-2650.