### PR TITLE
chore: consider client_id by creating load balancers

### DIFF
--- a/releases/dev/xelon-ccm.yml
+++ b/releases/dev/xelon-ccm.yml
@@ -49,6 +49,8 @@ spec:
               value: "INSERT_TOKEN_HERE"
             - name: XELON_API_URL
               value: "INSERT_API_URL_HERE"
+            - name: XELON_CLIENT_ID
+              value: "INSERT_CLIENT_ID_HERE"
             - name: XELON_CLOUD_ID
               value: "INSERT_CLOUD_ID_HERE"
             - name: XELON_CLUSTER_ID

--- a/releases/latest/xelon-ccm.yml
+++ b/releases/latest/xelon-ccm.yml
@@ -49,6 +49,8 @@ spec:
               value: "INSERT_TOKEN_HERE"
             - name: XELON_API_URL
               value: "INSERT_API_URL_HERE"
+            - name: XELON_CLIENT_ID
+              value: "INSERT_CLIENT_ID_HERE"
             - name: XELON_CLOUD_ID
               value: "INSERT_CLOUD_ID_HERE"
             - name: XELON_CLUSTER_ID


### PR DESCRIPTION
This PR considers new `XELON_CLIENT_ID` envvar by creating load balancers.

See: #2 