### PR TITLE
fix: update generated k8s manifest without k8s secret

### DIFF
--- a/charts/xelon-ccm/templates/deployment.yaml
+++ b/charts/xelon-ccm/templates/deployment.yaml
@@ -43,27 +43,27 @@ spec:
             - name: XELON_BASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: xelon-ccm-credentials
+                  name: xelon-api-credentials
                   key: baseUrl
             - name: XELON_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: xelon-ccm-credentials
+                  name: xelon-api-credentials
                   key: clientId
             - name: XELON_CLOUD_ID
               valueFrom:
                 secretKeyRef:
-                  name: xelon-ccm-credentials
+                  name: xelon-api-credentials
                   key: cloudId
             - name: XELON_KUBERNETES_CLUSTER_ID
               valueFrom:
                 secretKeyRef:
-                  name: xelon-ccm-credentials
+                  name: xelon-api-credentials
                   key: kubernetesClusterId
             - name: XELON_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: xelon-ccm-credentials
+                  name: xelon-api-credentials
                   key: token
           resources:
             requests:

--- a/charts/xelon-ccm/templates/secret.yaml
+++ b/charts/xelon-ccm/templates/secret.yaml
@@ -1,12 +1,14 @@
+{{- if .Values.xelonSecret.create -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: xelon-ccm-credentials
+  name: xelon-api-credentials
   namespace: kube-system
 type: Opaque
 stringData:
-  baseUrl: {{ .Values.xelon.baseUrl | quote }}
-  clientId: {{ .Values.xelon.clientId | quote }}
-  cloudId: {{ .Values.xelon.cloudId | quote }}
-  kubernetesClusterId: {{ .Values.xelon.kubernetesClusterId | quote }}
-  token: {{ .Values.xelon.token | quote }}
+  baseUrl: {{ .Values.xelonSecret.baseUrl | quote }}
+  clientId: {{ .Values.xelonSecret.clientId | quote }}
+  cloudId: {{ .Values.xelonSecret.cloudId | quote }}
+  kubernetesClusterId: {{ .Values.xelonSecret.kubernetesClusterId | quote }}
+  token: {{ .Values.xelonSecret.token | quote }}
+{{- end -}}

--- a/charts/xelon-ccm/values.yaml
+++ b/charts/xelon-ccm/values.yaml
@@ -9,8 +9,9 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
-xelon:
-  baseUrl: "https://vdc.xelon.ch/api/service/"
+xelonSecret:
+  create: false
+  baseUrl: "https://hq.xelon.ch/api/service/"
   clientId: ""
   cloudId: ""
   kubernetesClusterId: ""

--- a/deploy/xelon-ccm.yaml
+++ b/deploy/xelon-ccm.yaml
@@ -6,20 +6,6 @@ metadata:
   name: xelon-cloud-controller-manager
   namespace: kube-system
 ---
-# Source: xelon-cloud-controller-manager/templates/secret.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: xelon-ccm-credentials
-  namespace: kube-system
-type: Opaque
-stringData:
-  baseUrl: "INSERT_XELON_BASE_URL_HERE"
-  clientId: "INSERT_XELON_CLIENT_ID_HERE"
-  cloudId: "INSERT_XELON_CLOUD_ID_HERE"
-  kubernetesClusterId: "INSERT_XELON_KUBERNETES_CLUSTER_ID_HERE"
-  token: "INSERT_XELON_TOKEN_HERE"
----
 # Source: xelon-cloud-controller-manager/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -119,27 +105,27 @@ spec:
             - name: XELON_BASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: xelon-ccm-credentials
+                  name: xelon-api-credentials
                   key: baseUrl
             - name: XELON_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: xelon-ccm-credentials
+                  name: xelon-api-credentials
                   key: clientId
             - name: XELON_CLOUD_ID
               valueFrom:
                 secretKeyRef:
-                  name: xelon-ccm-credentials
+                  name: xelon-api-credentials
                   key: cloudId
             - name: XELON_KUBERNETES_CLUSTER_ID
               valueFrom:
                 secretKeyRef:
-                  name: xelon-ccm-credentials
+                  name: xelon-api-credentials
                   key: kubernetesClusterId
             - name: XELON_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: xelon-ccm-credentials
+                  name: xelon-api-credentials
                   key: token
           resources:
             requests:


### PR DESCRIPTION
The k8s secret will be injected during Talos k8s cluster creation process. So this PR creates the secret optionally (false per default).