### PR TITLE
fix: use golang:1.23 when building images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.22 AS builder
+FROM golang:1.23 AS builder
 
 ARG GIT_COMMIT
 ARG GIT_TREE_STATE


### PR DESCRIPTION
This PR fixes failing issue when building Docker images. Go version is updated to 1.23.