### PR TITLE
feat(loadbalancer): support proxy protocol version for k8s services

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23
 toolchain go1.23.0
 
 require (
-	github.com/Xelon-AG/xelon-sdk-go v0.15.1
+	github.com/Xelon-AG/xelon-sdk-go v0.15.4
 	github.com/go-logr/logr v1.4.1
 	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.28.13

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Xelon-AG/xelon-sdk-go v0.15.1 h1:G8u8wleUvZiKw/6PWCfU7WzMqKi1lins92tX1R61tGI=
-github.com/Xelon-AG/xelon-sdk-go v0.15.1/go.mod h1:Z8t2YsyXFopxTf6OTUWxIzYrdoPxb8XtzX6Ll50z4Kw=
+github.com/Xelon-AG/xelon-sdk-go v0.15.4 h1:nfKPzX5unCq3js8OkeHnCek/1sulebiVBB7fktMtFew=
+github.com/Xelon-AG/xelon-sdk-go v0.15.4/go.mod h1:Z8t2YsyXFopxTf6OTUWxIzYrdoPxb8XtzX6Ll50z4Kw=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df h1:7RFfzj4SSt6nnvCPbCqijJi1nWCd+TqAT3bYCStRC18=
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=

--- a/internal/xelon/load_balancers_reconciler.go
+++ b/internal/xelon/load_balancers_reconciler.go
@@ -38,7 +38,7 @@ func reconcile(currentRules []xelon.LoadBalancerClusterForwardingRule, desiredRu
 				continue
 			}
 			if currentRule.Frontend.Port == desiredRule.Frontend.Port &&
-				currentRule.Backend.Port != desiredRule.Backend.Port {
+				(currentRule.Backend.Port != desiredRule.Backend.Port || currentRule.Backend.ProxyProtocol != desiredRule.Backend.ProxyProtocol) {
 				desiredRule.Frontend.ID = currentRule.Frontend.ID
 				desiredRule.Backend.ID = currentRule.Backend.ID
 				reconcileDiff.rulesToUpdate = append(reconcileDiff.rulesToUpdate, desiredRule)

--- a/internal/xelon/load_balancers_reconciler_test.go
+++ b/internal/xelon/load_balancers_reconciler_test.go
@@ -23,37 +23,37 @@ func TestReconcile_createRules(t *testing.T) {
 		"nil current": {
 			current: nil,
 			desired: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 80800},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80800},
 			}},
 			expected: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 80800},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80800},
 			}},
 		},
 		"nil desired": {
 			current: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 80800},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80800},
 			}},
 			desired:  nil,
 			expected: nil,
 		},
 		"add rule from desired": {
 			current: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080, ID: "5qggn9mtbz"},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 80800},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080, ID: "5qggn9mtbz"},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80800},
 			}},
 			desired: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 80800},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80800},
 			}, {
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8090},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 80900},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8090},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80900},
 			}},
 			expected: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8090},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 80900},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8090},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80900},
 			}},
 		},
 	}
@@ -80,16 +80,30 @@ func TestReconcile_updateRules(t *testing.T) {
 		},
 		"update with new backend port": {
 			current: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080, ID: "5qggn9mtbz"},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 80800, ID: "u0gkddw9rr"},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080, ID: "5qggn9mtbz"},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80800, ID: "u0gkddw9rr"},
 			}},
 			desired: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 99999},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 99999},
 			}},
 			expected: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080, ID: "5qggn9mtbz"},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 99999, ID: "u0gkddw9rr"},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080, ID: "5qggn9mtbz"},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 99999, ID: "u0gkddw9rr"},
+			}},
+		},
+		"update with new proxy_protocol": {
+			current: []xelon.LoadBalancerClusterForwardingRule{{
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080, ID: "5qggn9mtbz"},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80800, ID: "u0gkddw9rr", ProxyProtocol: 0},
+			}},
+			desired: []xelon.LoadBalancerClusterForwardingRule{{
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80800, ProxyProtocol: 1},
+			}},
+			expected: []xelon.LoadBalancerClusterForwardingRule{{
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080, ID: "5qggn9mtbz"},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80800, ID: "u0gkddw9rr", ProxyProtocol: 1},
 			}},
 		},
 	}
@@ -116,16 +130,16 @@ func TestReconcile_deleteRules(t *testing.T) {
 		},
 		"remove non-used existed rule": {
 			current: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080, ID: "5qggn9mtbz"},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 80800},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080, ID: "5qggn9mtbz"},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80800},
 			}},
 			desired: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8090},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 80900},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8090},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80900},
 			}},
 			expected: []xelon.LoadBalancerClusterForwardingRule{{
-				Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080, ID: "5qggn9mtbz"},
-				Backend:  &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 80800},
+				Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080, ID: "5qggn9mtbz"},
+				Backend:  &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 80800},
 			}},
 		},
 	}

--- a/internal/xelon/load_balancers_test.go
+++ b/internal/xelon/load_balancers_test.go
@@ -32,9 +32,9 @@ func TestIsVirtualIPAvailable_reservedState(t *testing.T) {
 func TestIsVirtualIPAvailable_noFrontendForwardingRules(t *testing.T) {
 	virtualIP := &xelon.LoadBalancerClusterVirtualIP{State: "free"}
 	forwardingRules := []xelon.LoadBalancerClusterForwardingRule{
-		{Backend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080}},
-		{Backend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8081}},
-		{Backend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8082}},
+		{Backend: &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 8080}},
+		{Backend: &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 8081}},
+		{Backend: &xelon.LoadBalancerClusterForwardingRuleBackendConfiguration{Port: 8082}},
 	}
 	service := &v1.Service{Spec: v1.ServiceSpec{
 		Ports: []v1.ServicePort{
@@ -52,7 +52,7 @@ func TestIsVirtualIPAvailable_noFrontendForwardingRules(t *testing.T) {
 func TestIsVirtualIPAvailable_frontedPortExists(t *testing.T) {
 	virtualIP := &xelon.LoadBalancerClusterVirtualIP{State: "free"}
 	forwardingRules := []xelon.LoadBalancerClusterForwardingRule{
-		{Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080}},
+		{Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080}},
 	}
 	service := &v1.Service{Spec: v1.ServiceSpec{
 		Ports: []v1.ServicePort{
@@ -70,7 +70,7 @@ func TestIsVirtualIPAvailable_frontedPortExists(t *testing.T) {
 func TestIsVirtualIPAvailable_frontedPortAvailable(t *testing.T) {
 	virtualIP := &xelon.LoadBalancerClusterVirtualIP{State: "free"}
 	forwardingRules := []xelon.LoadBalancerClusterForwardingRule{
-		{Frontend: &xelon.LoadBalancerClusterForwardingRuleConfiguration{Port: 8080}},
+		{Frontend: &xelon.LoadBalancerClusterForwardingRuleFrontendConfiguration{Port: 8080}},
 	}
 	service := &v1.Service{Spec: v1.ServiceSpec{
 		Ports: []v1.ServicePort{


### PR DESCRIPTION
This PR adds a support for proxy protocol for k8s services.

Valid values:
  - 0: default value, don't send proxy protocol to the backend
  - 1: Proxy Protocol version 1 (text format)
  - 2: Proxy Protocol version 2 (binary format)

Example:
```
apiVersion: v1
kind: Service
metadata:
  annotations:
    service.beta.kubernetes.io/xelon-load-balancer-cluster-proxy-protocol-version: "2"
...
```